### PR TITLE
Segregate electron tests and required options

### DIFF
--- a/example/build.boot
+++ b/example/build.boot
@@ -9,6 +9,17 @@
 (require
  '[crisptrutski.boot-cljs-test :refer [test-cljs]])
 
+(task-options!
+  test-cljs {:namespaces #{"example.failing-test"
+                           "example.core-test"}})
+
+(deftask electron []
+  (task-options!
+    test-cljs {:namespaces #{"example.electron-test"
+                             "example.core-test"}
+               :js-env     :electron
+               :cljs-opts {:externs ["externs/electron.js"]}}))
+
 (deftask add-tests []
   (set-env! :source-paths #(conj % "test"))
   identity)

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "dependencies": {},
   "devDependencies": {
-    "karma": "^0.13.14",
+    "electron-prebuilt": "^0.36.2",
+    "karma": "^0.13.16",
     "karma-chrome-launcher": "^0.2.1",
     "karma-cljs-test": "^0.1.0",
     "karma-electron-launcher": "^0.1.0",


### PR DESCRIPTION
Have things almost working - this just fixes the non-karma boot tests, by adding a whitelist. Thinking of adding an `:exclusions` which takes a `#{ns-regexes}` parameter, that would be even simpler.

Another option is also just to use the runner scripts lein is using (by default `boot-cljs-test` lets you skip the `doo` dependency completely and with these changes generates its own runners). Think it's nice taking the slightly different approach in this repo though, tests get a bit more coverage.

Unfortunately there's a little bit of work on `doo` or `boot-cljs-test` is still needed to support Karma, as "files are below (System/getProperty "user.dir")`" assumption doesn't hold, they're under`~/.boot/cache/tmp/`.

Once that's sorted, testing `electron` in `circle.yml`  would look something like:

```
    - cd example && boot add-tests electron test-cljs -x
    - cd example && boot add-tests electron test-cljs -x -O advanced
```
