### PR TITLE
Add boot/electron tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,9 @@ test:
     - cd example && lein doo electron electron-test once
     - cd example && lein doo electron electron-advanced once
     - cd example && lein doo electron electron-none once
+    - cd example && boot add-tests electron test-cljs -x
+    - cd example && boot add-tests electron test-cljs -x -O simple
+    - cd example && boot add-tests electron test-cljs -x -O advanced
     # Phantom
     - cd example && lein doo phantom test once
     - cd example && lein doo phantom advanced once
@@ -61,6 +64,9 @@ test:
     - cd example && lein doo electron test-fail once && exit 1 || exit 0
     - cd example && lein doo electron advanced-fail once && exit 1 || exit 0
     - cd example && lein doo electron none-test-fail once && exit 1 || exit 0
+    - cd example && boot add-failures electron test-cljs -x && exit 1 || exit 0
+    - cd example && boot add-failures electron test-cljs -x -O simple && exit 1 || exit 0
+    - cd example && boot add-failures electron test-cljs -x -O advanced && exit 1 || exit 0
     # Phantom
     - cd example && lein doo phantom test-fail once && exit 1 || exit 0
     - cd example && lein doo phantom advanced-fail once && exit 1 || exit 0

--- a/example/build.boot
+++ b/example/build.boot
@@ -3,7 +3,7 @@
  :resource-paths  #{"resources"}
  :dependencies '[[org.clojure/core.async      "0.1.346.0-17112a-alpha"]
                  [org.clojure/clojurescript   "1.7.170"]
-                 [crisptrutski/boot-cljs-test "0.2.1-SNAPSHOT"]
+                 [crisptrutski/boot-cljs-test "0.2.1"]
                  [doo                         "0.1.7-SNAPSHOT"]])
 
 (require

--- a/example/build.boot
+++ b/example/build.boot
@@ -10,22 +10,25 @@
  '[crisptrutski.boot-cljs-test :refer [test-cljs]])
 
 (task-options!
-  test-cljs {:namespaces #{"example.failing-test"
-                           "example.core-test"}})
+  test-cljs {:debug? true
+             :namespaces #{"example.core-test"
+                           "example.failing-test"}})
 
 (deftask electron []
   (task-options!
-    test-cljs {:namespaces #{"example.electron-test"
-                             "example.core-test"}
-               :js-env     :electron
+    test-cljs {:debug? true
+               :js-env :electron
+               :namespaces #{"example.electron-test"
+                             "example.core-test"
+                             "example.failing-test"}
                :cljs-opts {:externs ["externs/electron.js"]}}))
 
 (deftask add-tests []
-  (set-env! :source-paths #(conj % "test"))
+  (merge-env! :source-paths #{"test"})
   identity)
 
 (deftask add-failures []
-  (set-env! :source-paths #(conj % "failing-tests"))
+  (merge-env! :source-paths #{"failing-tests"})
   identity)
 
 (deftask deps [])


### PR DESCRIPTION
Spruces up the `boot.build` file a bit too.

Actually forgot to include support for the `:debug?` parameter in the `0.2.1` build, but it'll be in `0.3.0` which will come out in a day or two.
